### PR TITLE
feat: Add JSX support to eslint configs

### DIFF
--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -11,7 +11,8 @@ const stylisticConfig = stylisticPlugin.configs.customize({
 	quotes: 'single',
 	semi: true,
 	commaDangle: 'never',
-	braceStyle: '1tbs'
+	braceStyle: '1tbs',
+	jsx: true
 });
 
 export default tseslint.config(
@@ -32,6 +33,13 @@ export default tseslint.config(
 			],
 			'one-var': ['error', 'never'],
 			'curly': ['error', 'all'] // Always require curly braces
+		},
+		languageOptions: {
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: true
+				}
+			}
 		}
 	},
 	{

--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -17,6 +17,10 @@ const stylisticConfig = stylisticPlugin.configs.customize({
 
 export default tseslint.config(
 	{
+		name: 'PretendoNetwork/files',
+		files: ['**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx', '**/*.mjs', '**/*.cjs', '**/*.d.ts']
+	},
+	{
 		// https://eslint.org/docs/rules/
 		name: 'PretendoNetwork/eslint-js',
 		extends: [eslint.configs.recommended],

--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -38,7 +38,7 @@ export default tseslint.config(
 		// https://typescript-eslint.io/rules/
 		name: 'PretendoNetwork/typescript-eslint',
 		extends: [tseslint.configs.recommended],
-		files: ['**/*.ts', '**/*.d.ts'],
+		files: ['**/*.ts', '**/*.tsx', '**/*.d.ts'],
 		rules: {
 			'@typescript-eslint/no-unused-vars': [
 				'error',
@@ -102,7 +102,7 @@ export default tseslint.config(
 		// https://www.npmjs.com/package/eslint-plugin-import - but specifically for TypeScript
 		name: 'PretendoNetwork/import-typescript',
 		extends: [importPlugin.flatConfigs.typescript],
-		files: ['**/*.ts', '**/*.d.ts'],
+		files: ['**/*.ts', '**/*.tsx', '**/*.d.ts'],
 		settings: {
 			'import/resolver': {
 				typescript: {
@@ -126,7 +126,7 @@ export default tseslint.config(
 	},
 	{
 		name: 'PretendoNetwork/global-esm',
-		files: ['**/*.ts', '**/*.d.ts', '**/*.mjs'],
+		files: ['**/*.ts', '**/*.tsx', '**/*.d.ts', '**/*.mjs'],
 		languageOptions: {
 			globals: {
 				...globals.builtin,

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pretendonetwork/eslint-config",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"main": "index.mjs",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
With https://github.com/PretendoNetwork/juxtaposition/pull/132 we are introducing JSX into the stack, which doesn't fully work with all the eslint configuration.

This PR adds the eslint configuration to make JSX lint properly.

Also includes a version bump