### PR TITLE
[ESLint] Update import rules

### DIFF
--- a/eslint-config/eslint.config.mjs
+++ b/eslint-config/eslint.config.mjs
@@ -1,4 +1,4 @@
-import config from './index.mjs';
+import config from './index.mjs'; // eslint-disable-line no-restricted-imports -- Will told me to ignore this here, signed - Jon
 
 export default [
 	...config

--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -102,7 +102,8 @@ export default tseslint.config(
 		rules: {
 			'import/order': ['warn', {
 				'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'type'],
-				'newlines-between': 'never'
+				'newlines-between': 'never',
+				'sortTypesGroup': true
 			}],
 			'import/first': 'error',
 			'import/consistent-type-specifier-style': ['error', 'prefer-top-level']

--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -105,7 +105,17 @@ export default tseslint.config(
 				'sortTypesGroup': true
 			}],
 			'import/first': 'error',
-			'import/consistent-type-specifier-style': ['error', 'prefer-top-level']
+			'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+			'import/no-relative-packages': 'warn',
+			'import/no-relative-parent-imports': 'warn',
+			'no-restricted-imports': ['warn', {
+				patterns: [
+					{
+						group: ['./\\*', '../\\*'],
+						message: 'Use import aliases over relative paths.'
+					}
+				]
+			}]
 		},
 		languageOptions: {
 			ecmaVersion: 'latest' // For some reason, the recommended config sets this to 2018, reset this to the default

--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -106,8 +106,6 @@ export default tseslint.config(
 			}],
 			'import/first': 'error',
 			'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
-			'import/no-relative-packages': 'warn',
-			'import/no-relative-parent-imports': 'warn',
 			'no-restricted-imports': ['warn', {
 				patterns: [
 					{

--- a/eslint-config/index.mjs
+++ b/eslint-config/index.mjs
@@ -2,7 +2,6 @@ import eslint from '@eslint/js';
 import eslintCommentPlugin from '@eslint-community/eslint-plugin-eslint-comments/configs';
 import stylisticPlugin from '@stylistic/eslint-plugin';
 import importPlugin from 'eslint-plugin-import';
-// eslint-disable-next-line import/no-unresolved -- For some reason, eslint doesn't like the TypeScript plugin
 import tseslint from 'typescript-eslint';
 import reactPlugin from 'eslint-plugin-react';
 import globals from 'globals';

--- a/eslint-config/package-lock.json
+++ b/eslint-config/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@pretendonetwork/eslint-config",
-	"version": "0.0.11",
+	"version": "0.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@pretendonetwork/eslint-config",
-			"version": "0.0.11",
+			"version": "0.1.2",
 			"dependencies": {
 				"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
 				"@stylistic/eslint-plugin": "^5.2.3",
@@ -1087,9 +1087,10 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pretendonetwork/eslint-config",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"main": "index.mjs",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Resolves #XXX

### Changes:

I tested these changes with a small local program, but not with one of our repos yet. Though it should work as expected

Updates the import rules to now do the following:

1. Type-only imports are now sorted
2. Import aliases are now preferred over relative paths (this is how our TypeScript servers have always handled things, so this should have been there since the start tbh)

Full disclosure that I think either my VSC setup is bugged, or VSC might be getting confused with these rules since I'm getting warnings like these:

<img width="1011" height="110" alt="Screenshot 2025-09-15 at 2 31 42 PM" src="https://github.com/user-attachments/assets/7bd4cdc4-0d95-49ce-8477-b6a6c2960988" />

That being said, using the `eslint` command itself shows the expected outputs

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.